### PR TITLE
Improve download options' texts

### DIFF
--- a/assets/js/downloadUtils.js
+++ b/assets/js/downloadUtils.js
@@ -105,6 +105,16 @@ function getSanitizedLinuxName (ext) {
   }
 }
 
+function getSanitizedName(release) {
+  if (release.url.includes('linux')) {
+    return getSanitizedLinuxName(release.ext)
+  }
+
+  const match = release.url.match(/^.*\/.*-\d+\.\d+\.\d+-([^.]*)\.(.*)$/)
+
+  return match && match.length === 3 ? `${match[1]}.${match[2]}` : release.ext
+}
+
 export async function setupDownloadButton () {
   const os = getOS();
   const downloadParent = document.getElementById("downloads");
@@ -147,7 +157,7 @@ export async function setupDownloadButton () {
       for (const release of releases) {
         const optionDiv = document.createElement('div')
         optionDiv.classList.add('option')
-        optionDiv.innerHTML = `${getSanitizedLinuxName(release.ext)}`
+        optionDiv.innerHTML = `${getSanitizedName(release)}`
         optionsContainer.appendChild(optionDiv)
 
         optionDiv.onclick = () => window.open(release.url)


### PR DESCRIPTION
In the cases not specified in `getSanitizedLinuxName` only the extensions show up.

Example in Windows:
<img width="258" alt="image" src="https://github.com/Moosync/Moosync.github.io/assets/4430606/80ecdb06-3e05-4d26-8d18-440e709500e8">

This PR makes it at least display the architecture/variation, in addition to the extension, based on the release asset url:
<img width="252" alt="image" src="https://github.com/Moosync/Moosync.github.io/assets/4430606/df3b8b61-3c2a-401a-bc22-cf21098ef700">
